### PR TITLE
feat(mediatype): Add support for media types

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,9 @@ const bent = (...args) => {
     }
     if (encoding === 'json') {
       let c = caseless(request.headers)
-      c.set('accept', 'application/json')
+      if (!c.get('accept')) {
+        c.set('accept', 'application/json')
+      }
     }
     return new Promise((resolve, reject) => {
       let req = h.request(request, res => {

--- a/tests/test-basics.js
+++ b/tests/test-basics.js
@@ -69,6 +69,18 @@ httpTest('basic json', async t => {
   t.same({ok: 200}, json)
 })
 
+paths['/media-type'] = (req, res) => {
+  res.setHeader('content-type', 'application/json')
+  res.end(JSON.stringify({ok: 200, accept: req.headers.accept}))
+}
+
+httpTest('json based media type', async t => {
+  t.plan(1)
+  let request = bent('json', { accept: 'application/vnd.something.com' })
+  let json = await request('http://localhost:3000/media-type')
+  t.same({ok: 200, accept: 'application/vnd.something.com'}, json)
+})
+
 test('basic PUT', async t => {
   t.plan(2)
   let body = await promisify(cb => crypto.randomBytes(1024, cb))()


### PR DESCRIPTION
I was trying to use the GitHub API with `bent` and was getting `Incorrect statusCode: 415`. I figured out that it was because I was passing an accept header (because [sometimes you need it](https://developer.github.com/v3/media/) in the GitHub API and others) but at the same time `bent` was adding another value because of the `json` encoding. So this PR just checks if there's already a value for the `Accept` header, and in that case it doesn't add it.

btw, I love the approach of this project. Congrats