### PR TITLE
Remove patreon button

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,6 @@
 
 Functional HTTP client for Node.js w/ async/await.
 
-<p>
-  <a href="https://www.patreon.com/bePatron?u=880479">
-    <img src="https://c5.patreon.com/external/logo/become_a_patron_button.png" height="40px" />
-  </a>
-</p>
-
 ## Usage
 
 ```javascript


### PR DESCRIPTION
I saw that the button was redirecting to the patreon home page. Then doing a quick search I found that you've shut down your patreon page. So this PR just removes the button.