### PR TITLE
feat: reduce npm package size

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/mikeal/bent.git"
-  }
+  },
+  "files": [
+    "index.js"
+  ]
 }


### PR DESCRIPTION
This tiny npm lib could be tinier still by adding a file whitelist (via `files` in package.json). 

This change ultimately drops `.travis.yml` and `tests/` directory. Taking uncompressed size from 15.8kb -> 6.6kb

Before:
```
bent ♞  npm publish --dry-run
npm notice
npm notice 📦  bent@0.0.0-development
npm notice === Tarball Contents ===
npm notice 1.0kB package.json
npm notice 376B  .travis.yml
npm notice 3.6kB index.js
npm notice 2.0kB README.md
npm notice 1.3kB tests/server.crt
npm notice 1.7kB tests/server.key
npm notice 4.0kB tests/test-basics.js
npm notice 1.1kB tests/test-errors.js
npm notice 728B  tests/test-https.js
npm notice === Tarball Details ===
npm notice name:          bent
npm notice version:       0.0.0-development
npm notice package size:  6.2 kB
npm notice unpacked size: 15.8 kB
npm notice shasum:        42fd3116c50081628bd83a606be2f19924be4e84
npm notice integrity:     sha512-sdZcPSzOvpTA9[...]VelIkBEMqVnZg==
npm notice total files:   9
npm notice
```

After:
```
bent ♞  npm publish --dry-run
npm notice
npm notice 📦  bent@0.0.0-development
npm notice === Tarball Contents ===
npm notice 1.0kB package.json
npm notice 3.6kB index.js
npm notice 2.0kB README.md
npm notice === Tarball Details ===
npm notice name:          bent
npm notice version:       0.0.0-development
npm notice package size:  2.6 kB
npm notice unpacked size: 6.6 kB
npm notice shasum:        5aaea4c68f62c9815594b6661f3350737e88097d
npm notice integrity:     sha512-wz6KtN5BDeF9A[...]Yzn0WnKo5anvw==
npm notice total files:   3
npm notice
```