### PR TITLE
Add note about options order

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ As you can see, bent is a function that returns an async function.
 Bent takes options which constrain what is accepted by the client.
 Any response that falls outside the constraints will generate an error.
 
-You can provide these options in any order, and Bent will figure out which option is which by inspecting the option's type.
+You can provide these options in any order, and Bent will figure out which option is which by inspecting the option's type and content.
 ```javascript
 const post = bent('http://localhost:3000/', 'POST', 'json', 200);
 const response = await post('cars/new', {name: 'bmw', wheels: 4});

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ As you can see, bent is a function that returns an async function.
 Bent takes options which constrain what is accepted by the client.
 Any response that falls outside the constraints will generate an error.
 
+You can provide these options in any order, and Bent will figure out which option is which by inspecting the option's type.
+```javascript
+const post = bent('http://localhost:3000/', 'POST', 'json', 200);
+const response = await post('cars/new', {name: 'bmw', wheels: 4});
+```
+
 If you don't set a response encoding (`'json'`, `'string'` or `'buffer'`)
 then the response stream will be returned after the statusCode check.
 


### PR DESCRIPTION
Clarification for people who come from `request`, they expect an options object. In `Bent` you can just pass separate options.