### PR TITLE
feat: Automated content encoding

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "browser": "src/browser.js",
   "scripts": {
     "test": "hundreds aegir test -t node browser",
-    "pretest": "aegir lint"
+    "pretest": "aegir lint",
+    "coverage": "nyc --reporter=html mocha test/*.spec.js && npx http-server coverage"
   },
   "keywords": [],
   "author": "Mikeal Rogers <mikeal.rogers@gmail.com> (http://www.mikealrogers.com)",

--- a/src/nodejs.js
+++ b/src/nodejs.js
@@ -11,9 +11,12 @@ const { PassThrough } = require('stream')
 
 const compression = {}
 
+/* istanbul ignore else */
 if (zlib.createBrotliDecompress) compression.br = () => zlib.createBrotliDecompress()
+/* istanbul ignore else */
 if (zlib.createGunzip) compression.gzip = () => zlib.createGunzip()
-if (zlib.createDeflate) compression.deflate = () => zlib.createDeflate()
+/* istanbul ignore else */
+if (zlib.createInflate) compression.deflate = () => zlib.createInflate()
 
 const acceptEncoding = Object.keys(compression).join(', ')
 
@@ -79,7 +82,7 @@ const mkrequest = (statusCodes, method, encoding, headers, baseurl) => (_url, bo
       c.set('accept', 'application/json')
     }
   }
-  if (!c.has('acccept-encoding')) {
+  if (!c.has('accept-encoding')) {
     c.set('accept-encoding', acceptEncoding)
   }
   return new Promise((resolve, reject) => {

--- a/src/nodejs.js
+++ b/src/nodejs.js
@@ -6,6 +6,32 @@ const isStream = require('is-stream')
 const caseless = require('caseless')
 const bytes = require('bytesish')
 const bent = require('./core')
+const zlib = require('zlib')
+const { PassThrough } = require('stream')
+
+const compression = {}
+
+if (zlib.createBrotliDecompress) compression.br = () => zlib.createBrotliDecompress()
+if (zlib.createGunzip) compression.gzip = () => zlib.createGunzip()
+if (zlib.createDeflate) compression.deflate = () => zlib.createDeflate()
+
+const acceptEncoding = Object.keys(compression).join(', ')
+
+const getResponse = resp => {
+  const ret = new PassThrough()
+  ret.statusCode = resp.statusCode
+  ret.statusMessage = resp.statusMessage
+  ret.headers = resp.headers
+  ret._response = resp
+  if (ret.headers['content-encoding']) {
+    const encodings = ret.headers['content-encoding'].split(', ').reverse()
+    while (encodings.length) {
+      const enc = encodings.shift()
+      resp = resp.pipe(compression[enc]())
+    }
+  }
+  return resp.pipe(ret)
+}
 
 class StatusError extends Error {
   constructor (res, ...params) {
@@ -47,11 +73,14 @@ const mkrequest = (statusCodes, method, encoding, headers, baseurl) => (_url, bo
     headers: headers || {},
     hostname: parsed.hostname
   }
+  const c = caseless(request.headers)
   if (encoding === 'json') {
-    const c = caseless(request.headers)
     if (!c.get('accept')) {
       c.set('accept', 'application/json')
     }
+  }
+  if (!c.has('acccept-encoding')) {
+    c.set('accept-encoding', acceptEncoding)
   }
   return new Promise((resolve, reject) => {
     const req = h.request(request, async res => {
@@ -59,6 +88,8 @@ const mkrequest = (statusCodes, method, encoding, headers, baseurl) => (_url, bo
       if (!statusCodes.has(res.statusCode)) {
         return reject(new StatusError(res))
       }
+      res = getResponse(res)
+
       if (!encoding) return resolve(res)
       else {
         const buff = await getBuffer(res)

--- a/test/compression.spec.js
+++ b/test/compression.spec.js
@@ -1,0 +1,50 @@
+'use strict'
+const bent = require('../')
+const assert = require('assert')
+const tsame = require('tsame')
+const qs = require('querystring')
+const zlib = require('zlib')
+const { it } = require('mocha')
+
+const test = it
+
+const same = (x, y) => assert.ok(tsame(x, y))
+
+const baseurl = 'https://echo-server.mikeal.now.sh/src'
+const u = path => baseurl + path
+
+if (!process.browser) {
+  test('accept header', async () => {
+    let request = bent('json')
+    let json = await request(u('/info.js'))
+    same(json.headers['accept-encoding'], 'br, gzip, deflate')
+
+    request = bent('json', { 'Accept-Encoding': 'test' })
+    json = await request(u('/info.js'))
+    same(json.headers['accept-encoding'], 'test')
+  })
+
+  test('brotli', async () => {
+    const request = bent('string', baseurl)
+    const base64 = zlib.brotliCompressSync('ok').toString('base64')
+    const headers = 'content-encoding:br'
+    const str = await request(`/echo.js?${qs.stringify({ base64, headers })}`)
+    same(str, 'ok')
+  })
+
+  test('gzip', async () => {
+    const request = bent('string', baseurl)
+    const base64 = zlib.gzipSync('ok').toString('base64')
+    const headers = 'content-encoding:gzip'
+    const str = await request(`/echo.js?${qs.stringify({ base64, headers })}`)
+    same(str, 'ok')
+  })
+
+  test('deflate', async () => {
+    const request = bent('string', baseurl)
+    const base64 = zlib.deflateSync('ok').toString('base64')
+    const headers = 'content-encoding:deflate'
+    const str = await request(`/echo.js?${qs.stringify({ base64, headers })}`)
+    same(str, 'ok')
+  })
+}


### PR DESCRIPTION
BREAKING CHANGE: the response stream is no longer the raw http client response in Node.js. It’s now a PassThrough stream with relevant properties copied over.

This change brings Node.js closer to default browser behavior. Transport compression is handled transparently in the browser but, until this change, was not handled automatically in Node.js.

Tests are disabled for this behavior in the browser since there’s no need for this feature to exist in `bent`.

This change means `bent` now supports `gzip`, `deflate` and `brotli` transparently without any changes to the API usage.