### PR TITLE
Overriding headers in request function

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,13 @@ The returned async function is used for subsequent requests.
 When working with Binary this library uses different types in the browser and Node.js. In Node.js all binary must be done
 the `Buffer` type. In the browser you can use ArrayBuffer or any ArrayBuffer view type (UInt8Array, etc).
 
-### `async request(url[, body=null])`
+### `async request(url[, body=null, headers={}])`
 
 * **url**: Fully qualified URL to the remote resource, or in the case that a
   base URL is passed the remaining URL string.
 * **body**: Request body. Can be a string, a stream (node.js), a buffer (node.js),
   an ArrayBuffer (browser), or a JSON object.
+* **headers**: An object of any headers you need to set for just this request.
 
 ```javascript
 const bent = require('bent')

--- a/src/browser.js
+++ b/src/browser.js
@@ -37,10 +37,9 @@ const mkrequest = (statusCodes, method, encoding, headers, baseurl) => async (_u
     }
   }
 
-  if (headers) headers = Object.assign({}, headers, _headers)
-  else headers = _headers
+  _headers = { ...(headers || {}), ..._headers}
 
-  const resp = await fetch(_url, { method, headers, body })
+  const resp = await fetch(_url, { method, headers: _headers, body })
   resp.statusCode = resp.status
 
   if (!statusCodes.has(resp.status)) {

--- a/src/browser.js
+++ b/src/browser.js
@@ -37,8 +37,8 @@ const mkrequest = (statusCodes, method, encoding, headers, baseurl) => async (_u
     }
   }
 
-  if (headers) headers = Object.assign({}, headers, _headers);
-  else headers = _headers;
+  if (headers) headers = Object.assign({}, headers, _headers)
+  else headers = _headers
 
   const resp = await fetch(_url, { method, headers, body })
   resp.statusCode = resp.status

--- a/src/browser.js
+++ b/src/browser.js
@@ -14,7 +14,7 @@ class StatusError extends Error {
   }
 }
 
-const mkrequest = (statusCodes, method, encoding, headers, baseurl) => async (_url, body) => {
+const mkrequest = (statusCodes, method, encoding, headers, baseurl) => async (_url, body, _headers = {}) => {
   _url = baseurl + _url
   const parsed = new URL(_url)
 
@@ -36,6 +36,9 @@ const mkrequest = (statusCodes, method, encoding, headers, baseurl) => async (_u
       throw new Error('Unknown body type.')
     }
   }
+
+  if (headers) headers = Object.assign({}, headers, _headers);
+  else headers = _headers;
 
   const resp = await fetch(_url, { method, headers, body })
   resp.statusCode = resp.status

--- a/src/nodejs.js
+++ b/src/nodejs.js
@@ -58,7 +58,7 @@ const getBuffer = stream => new Promise((resolve, reject) => {
   stream.on('data', d => parts.push(d))
 })
 
-const mkrequest = (statusCodes, method, encoding, headers, baseurl) => (_url, body = null) => {
+const mkrequest = (statusCodes, method, encoding, headers, baseurl) => (_url, body = null, _headers = {}) => {
   _url = baseurl + _url
   const parsed = new URL(_url)
   let h
@@ -73,7 +73,7 @@ const mkrequest = (statusCodes, method, encoding, headers, baseurl) => (_url, bo
     path: parsed.pathname + parsed.search,
     port: parsed.port,
     method: method,
-    headers: headers || {},
+    headers: Object.assign({}, headers || {}, _headers),
     hostname: parsed.hostname
   }
   const c = caseless(request.headers)

--- a/src/nodejs.js
+++ b/src/nodejs.js
@@ -73,7 +73,7 @@ const mkrequest = (statusCodes, method, encoding, headers, baseurl) => (_url, bo
     path: parsed.pathname + parsed.search,
     port: parsed.port,
     method: method,
-    headers: Object.assign({}, headers || {}, _headers),
+    headers: { ...(headers || {}), ..._headers },
     hostname: parsed.hostname
   }
   const c = caseless(request.headers)

--- a/test/basics.spec.js
+++ b/test/basics.spec.js
@@ -137,3 +137,11 @@ test('500 Response body', async () => {
     same(buffer.toString(), 'ok')
   }
 })
+
+test('override headers', async () => {
+  const request = bent('json', { 'X-Default': 'ok', 'X-Override-Me': 'not overriden' })
+  const info = await request(u('/info.js'), null, { 'X-Override-Me': 'overriden', 'X-New': 'ok' })
+  same(info.headers['x-default'], 'ok')
+  same(info.headers['x-override-me'], 'overriden')
+  same(info.headers['x-new'], 'ok')
+})


### PR DESCRIPTION
Often found myself needing to set headers at request time rather than when constructing the request function, so I added it.

Can be used for stuff like authorization headers in a SPA I guess, but it's also useful for libraries like `form-data`.