### PR TITLE
fix: only use Error.captureStackTrace if available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage
 package-lock.json
 node_modules
 .DS_Store
+yarn.lock

--- a/src/browser.js
+++ b/src/browser.js
@@ -6,7 +6,10 @@ class StatusError extends Error {
   constructor (res, ...params) {
     super(...params)
 
-    Error.captureStackTrace(this, StatusError)
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, StatusError)
+    }
+    
     this.message = `Incorrect statusCode: ${res.status}`
     this.statusCode = res.status
     this.res = res


### PR DESCRIPTION
Noticed during some testing on my own site, that StatusError's don't properly throw on non-Chromium browsers due to `Error.captureStackTrace` being a V8-only extension. Fixed this by adding an if around it like there is on the MDN.