### PR TITLE
fix: preserve basic auth in nodejs if present

### DIFF
--- a/src/nodejs.js
+++ b/src/nodejs.js
@@ -76,6 +76,9 @@ const mkrequest = (statusCodes, method, encoding, headers, baseurl) => (_url, bo
     headers: { ...(headers || {}), ..._headers },
     hostname: parsed.hostname
   }
+  if (parsed.username || parsed.password) {
+    request.auth = [parsed.username, parsed.password].join(':')
+  }
   const c = caseless(request.headers)
   if (encoding === 'json') {
     if (!c.get('accept')) {


### PR DESCRIPTION
This PR closes https://github.com/mikeal/bent/issues/64 by using the `username` and `password` values parsed from the request URL to populate the `auth` option used by nodejs http/s.