### PR TITLE
Unknown encoding fix

### DIFF
--- a/src/nodejs.js
+++ b/src/nodejs.js
@@ -30,7 +30,11 @@ const getResponse = resp => {
     const encodings = ret.headers['content-encoding'].split(', ').reverse()
     while (encodings.length) {
       const enc = encodings.shift()
-      resp = resp.pipe(compression[enc]())
+      if (compression[enc]) {
+        resp = resp.pipe(compression[enc]())
+      } else {
+        break
+      }
     }
   }
   return resp.pipe(ret)

--- a/test/test-compression.js
+++ b/test/test-compression.js
@@ -47,4 +47,15 @@ if (!process.browser) {
     const str = await request(`/echo.js?${qs.stringify({ base64, headers })}`)
     same(str, 'ok')
   })
+
+  test('unknown', async () => {
+    const request = bent('buffer', baseurl)
+    const base64 = zlib.gzipSync('untouched').toString('base64')
+    const headers = 'content-encoding:myown'
+    const buffer = await request(`/echo.js?${qs.stringify({ base64, headers })}`)
+    console.log(buffer)
+    const str = zlib.gunzipSync(buffer).toString('utf8')
+    console.log(str)
+    same(str, 'untouched')
+  })
 }

--- a/test/test-compression.js
+++ b/test/test-compression.js
@@ -53,9 +53,7 @@ if (!process.browser) {
     const base64 = zlib.gzipSync('untouched').toString('base64')
     const headers = 'content-encoding:myown'
     const buffer = await request(`/echo.js?${qs.stringify({ base64, headers })}`)
-    console.log(buffer)
     const str = zlib.gunzipSync(buffer).toString('utf8')
-    console.log(str)
     same(str, 'untouched')
   })
 }


### PR DESCRIPTION
A described in https://github.com/mikeal/bent/issues/77 bent crashes when receiving an unsupported content encoding.

This patch simply checks whether the content encoding is supported, and if not supported it will not try to decompress the response but pass it as-is to the client who may have a better understanding of what is going on.