### PR TITLE
Fix (#81) Address error responses not being handle the same as good responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Bent takes options which constrain what is accepted by the client.
 Any response that falls outside the constraints will generate an error.
 
 You can provide these options in any order, and Bent will figure out which option is which by inspecting the option's type and content.
+
 ```javascript
 const post = bent('http://localhost:3000/', 'POST', 'json', 200);
 const response = await post('cars/new', {name: 'bmw', wheels: 4});
@@ -31,6 +32,14 @@ const response = await post('cars/new', {name: 'bmw', wheels: 4});
 
 If you don't set a response encoding (`'json'`, `'string'` or `'buffer'`)
 then the *native* response object will be returned after the statusCode check.
+It is possible to set different expected encoding types for both success
+and error responses.
+
+```javascript
+const bent = require('bent')
+
+const get = bent('http://site.com', { onSuccessEncode: 'json', onErrorEncode: 'string' })
+```
 
 ```javascript
 const bent = require('bent')

--- a/src/common.js
+++ b/src/common.js
@@ -1,0 +1,33 @@
+'use strict'
+/**
+ * The types of encoding states which can be defined for the success or failure from a request.
+ */
+const stateEncode = ['onSuccessEncode', 'onErrorEncode']
+
+/**
+ * Makes a buffer from a response stream.
+ *
+ * @param {stream} stream a response stream to read as a buffer
+ */
+const getBuffer = stream => new Promise((resolve, reject) => {
+  const parts = []
+  stream.on('error', reject)
+  stream.on('end', () => resolve(Buffer.concat(parts)))
+  stream.on('data', d => parts.push(d))
+})
+
+/**
+ * Gets the encoding type which matches the 'stateEncode' object.
+ *
+ * @param {object|string} encoding a string or an object which contains properties which match stateEncode
+ * @param {boolean} isError if the encoding state is or is not an error
+ */
+const getEncoding = (encoding, isError) => {
+  return typeof encoding === 'object' ? isError ? encoding[stateEncode[1]] : encoding[stateEncode[0]] : encoding
+}
+
+module.exports = {
+  getBuffer,
+  getEncoding,
+  stateEncode
+}

--- a/test/test-basics.js
+++ b/test/test-basics.js
@@ -129,11 +129,12 @@ test('500 Response body', async () => {
   } catch (e) {
     body = e.responseBody
   }
-  const buffer = await body
+
   if (process.browser) {
+    const buffer = await body
     same(decode(buffer), 'ok')
   } else {
-    same(buffer.toString(), 'ok')
+    same(body, 'ok')
   }
 })
 


### PR DESCRIPTION
This review addresses error responses where there is a valid body (see #81). It also removes the need to await for a responseBody in an error condition.