### PR TITLE
Add headers attribute in StatusError object

### DIFF
--- a/src/nodejs.js
+++ b/src/nodejs.js
@@ -47,6 +47,7 @@ class StatusError extends Error {
     Error.captureStackTrace(this, StatusError)
     this.message = `Incorrect statusCode: ${res.statusCode}`
     this.statusCode = res.statusCode
+    this.headers = res.headers
     this.responseBody = new Promise((resolve) => {
       const buffers = []
       res.on('data', chunk => buffers.push(chunk))

--- a/test/test-basics.js
+++ b/test/test-basics.js
@@ -178,3 +178,14 @@ if (process.browser) {
     server.close()
   })
 }
+
+test('error headers', async () => {
+  const request = bent(200)
+  let headers
+  try {
+    await request(u('/echo.js?statusCode=500&body=ok'))
+  } catch (e) {
+    headers = e.headers
+  }
+  same(headers !== 'undefined', true)
+})


### PR DESCRIPTION
Hi, I think error response should contains headers. I was trying to follow a redirect in a 301 status code but would be impossible if location header is not present.

What do you think about this approach? Would be another good solutions in order to follow redirects?

Thanks so much for reviewing.