### PR TITLE
Add responseHeaders property to error objects (#92)

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -14,6 +14,7 @@ class StatusError extends Error {
     this.statusCode = res.status
     this.res = res
     this.responseBody = res.arrayBuffer()
+    this.responseHeaders = {}
   }
 }
 

--- a/src/nodejs.js
+++ b/src/nodejs.js
@@ -47,6 +47,8 @@ class StatusError extends Error {
     Error.captureStackTrace(this, StatusError)
     this.message = `Incorrect statusCode: ${res.statusCode}`
     this.statusCode = res.statusCode
+    this.res = res
+    this.responseHeaders = res.headers
     this.responseBody = new Promise((resolve) => {
       const buffers = []
       res.on('data', chunk => buffers.push(chunk))

--- a/test/test-basics.js
+++ b/test/test-basics.js
@@ -94,6 +94,7 @@ test('status 201', async () => {
     throw new Error('Call should have thrown.')
   } catch (e) {
     same(e.message, 'Incorrect statusCode: 200')
+    assert.ok(Object.prototype.toString.call(e.responseHeaders) === '[object Object]')
   }
 })
 


### PR DESCRIPTION
  - Also adds res property (Node.js) to match browser object.
  - responseHeaders is always {} on browser due to underlying implementation difference.

Closes #92