### PR TITLE
HTTP-redirect

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -34,7 +34,7 @@ const mkrequest = (statusCodes, method, encoding, headers, baseurl) => {
   const rep = async (_url, body, _headers = {}) => {
     _url = baseurl + (_url || '')
     let parsed = new URL(_url)
-  
+
     if (!headers) headers = {}
     if (parsed.username) {
       headers.Authorization = 'Basic ' + btoa(parsed.username + ':' + parsed.password)
@@ -43,7 +43,7 @@ const mkrequest = (statusCodes, method, encoding, headers, baseurl) => {
     if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
       throw new Error(`Unknown protocol, ${parsed.protocol}`)
     }
-  
+
     if (body) {
       if (body instanceof ArrayBuffer ||
         ArrayBuffer.isView(body) ||
@@ -57,7 +57,7 @@ const mkrequest = (statusCodes, method, encoding, headers, baseurl) => {
         throw new Error('Unknown body type.')
       }
     }
-  
+
     _headers = new Headers({ ...(headers || {}), ..._headers })
 
     const opts = { method, headers: _headers, body }
@@ -67,11 +67,11 @@ const mkrequest = (statusCodes, method, encoding, headers, baseurl) => {
 
     const resp = await fetch(parsed, opts)
     resp.statusCode = resp.status
-  
+
     if (!statusCodes.has(resp.status)) {
       throw new StatusError(resp)
     }
-  
+
     if (encoding === 'json') return resp.json()
     else if (encoding === 'buffer') return resp.arrayBuffer()
     else if (encoding === 'string') return resp.text()

--- a/src/nodejs.js
+++ b/src/nodejs.js
@@ -95,7 +95,7 @@ const redirCodes = new Set([301, 302, 303, 307, 308])
 const mkrequest = (statusCodes, method, encoding, headers, baseurl) => {
   const rep = (_url, body = null, _headers = {}, redirLength = 0) => {
     if (redirLength === 20) {
-      throw new Error("Max redirects exceeded")
+      throw new Error('Max redirects exceeded')
     }
 
     _url = baseurl + (_url || '')
@@ -133,7 +133,7 @@ const mkrequest = (statusCodes, method, encoding, headers, baseurl) => {
         decodings(res)
         res.status = res.statusCode
         if (!statusCodes.has(res.statusCode)) {
-          if (rep.redirect === "follow" && redirCodes.has(res.statusCode)) {
+          if (rep.redirect === 'follow' && redirCodes.has(res.statusCode)) {
             if (res.headers.location) {
               let next = null
               try {
@@ -142,19 +142,19 @@ const mkrequest = (statusCodes, method, encoding, headers, baseurl) => {
                 try {
                   next = new URL(parsed.origin + res.headers.location)
                 } catch (err) {
-                  return reject(new Error("Redirect with invalid Location header"))
+                  return reject(new Error('Redirect with invalid Location header'))
                 }
               }
 
               return rep(next.href, body, _headers, redirLength + 1)
             } else {
-              return reject(new Error("Redirect without Location header"))
+              return reject(new Error('Redirect without Location header'))
             }
           } else {
             return reject(new StatusError(res))
           }
         }
-  
+
         if (!encoding) return resolve(res)
         else {
           /* istanbul ignore else */


### PR DESCRIPTION
## Overview

This PR implements a HTTP-redirect

In Node side:

- The redirect codes has been retrieved from [https://fetch.spec.whatwg.org/#statuses](https://fetch.spec.whatwg.org/#statuses)

- The 20 redirects convention was followed as well [https://fetch.spec.whatwg.org/#http-redirect-fetch](https://fetch.spec.whatwg.org/#http-redirect-fetch)

- The "manual" behavior **was not been implemented yet**

In Browser side:

- The redirect value is passed to `fetch` options 😀

## Interface

```javascript
const getJSON = bent("json");

getJSON.redirect = "follow"; // manual, *follow, error
```
"manual" has no effect on Node side

Closes #87 