### PR TITLE
bubble up zlib errors

### DIFF
--- a/src/nodejs.js
+++ b/src/nodejs.js
@@ -33,7 +33,7 @@ const getResponse = resp => {
       const enc = encodings.shift()
       if (compression[enc]) {
         const decompress = compression[enc]()
-        decompress.on('error', (e) => ret.emit('error', e))
+        decompress.on('error', (e) => ret.emit('error', new Error('ZBufError', e)))
         resp = resp.pipe(decompress)
       } else {
         break

--- a/src/nodejs.js
+++ b/src/nodejs.js
@@ -125,6 +125,7 @@ const mkrequest = (statusCodes, method, encoding, headers, baseurl) => (_url, bo
   return new Promise((resolve, reject) => {
     const req = h.request(request, async res => {
       res = getResponse(res)
+      res.on('error', reject)
       decodings(res)
       res.status = res.statusCode
       if (!statusCodes.has(res.statusCode)) {

--- a/src/nodejs.js
+++ b/src/nodejs.js
@@ -32,7 +32,9 @@ const getResponse = resp => {
     while (encodings.length) {
       const enc = encodings.shift()
       if (compression[enc]) {
-        resp = resp.pipe(compression[enc]())
+        const decompress = compression[enc]()
+        decompress.on('error', (e) => ret.emit('error', e))
+        resp = resp.pipe(decompress)
       } else {
         break
       }


### PR DESCRIPTION
fixes #101 

after this fix. instead of and Unhandled error in the zlib stream. it will reject the promise

**Before**
throw er; // Unhandled 'error' event
      ^
Error: incorrect header check
    at Zlib.zlibOnError [as onerror] (zlib.js:164:17)
Emitted 'error' event at:
    at errorOrDestroy (internal/streams/destroy.js:107:12)
    at Gunzip.onerror (_stream_readable.js:732:7)
    at Gunzip.emit (events.js:198:13)
    at Zlib.zlibOnError [as onerror] (zlib.js:167:8)
 
**AFTER**

Error can be caught by the application code

 { Error: incorrect header check
    at Zlib.zlibOnError [as onerror] (zlib.js:164:17) errno: -3, code: 'Z_DATA_ERROR' }