### PR TITLE
allow statusCodes to be passed as an array or a set

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -29,7 +29,7 @@ module.exports = mkrequest => (...args) => {
     } else if (typeof arg === 'number') {
       statusCodes.add(arg)
     } else if (typeof arg === 'object') {
-      if (Array.isArray(arg)) {
+      if (Array.isArray(arg) || arg instanceof Set) {
         arg.forEach(code => statusCodes.add(code))
       } else {
         if (headers) {

--- a/src/core.js
+++ b/src/core.js
@@ -29,10 +29,14 @@ module.exports = mkrequest => (...args) => {
     } else if (typeof arg === 'number') {
       statusCodes.add(arg)
     } else if (typeof arg === 'object') {
-      if (headers) {
-        throw new Error('Cannot set headers twice.')
+      if (Array.isArray(arg)) {
+        arg.forEach(code => statusCodes.add(code))
+      } else {
+        if (headers) {
+          throw new Error('Cannot set headers twice.')
+        }
+        headers = arg
       }
-      headers = arg
     } else {
       throw new Error(`Unknown type: ${typeof arg}`)
     }

--- a/test/test-basics.js
+++ b/test/test-basics.js
@@ -149,7 +149,7 @@ test('multiple status', async () => {
     await request(u('/echo.js?statusCode=202&body=ok'))
     throw new Error('Call should have thrown.')
   } catch (e) {
-    same(e.message, process.browser ? null : 'OK')
+    same(e.message, process.browser ? null : 'Accepted')
     // basic header test
     same(e.headers['content-length'], '2')
   }

--- a/test/test-basics.js
+++ b/test/test-basics.js
@@ -137,6 +137,24 @@ if (process.browser) {
   })
 }
 
+test('multiple status', async () => {
+  const request = bent('string', [200, 201])
+  const str200 = await request(u('/echo.js?body=ok'))
+  same(str200, 'ok')
+
+  const str201 = await request(u('/echo.js?statusCode=201&body=ok'))
+  same(str201, 'ok')
+
+  try {
+    await request(u('/echo.js?statusCode=202&body=ok'))
+    throw new Error('Call should have thrown.')
+  } catch (e) {
+    same(e.message, process.browser ? null : 'OK')
+    // basic header test
+    same(e.headers['content-length'], '2')
+  }
+})
+
 test('PUT stream', async () => {
   const body = Buffer.from(Math.random().toString())
   const request = bent('PUT', 'json')


### PR DESCRIPTION
Before this PR, you were only able to specify a single acceptable status code, as the type check for args was only for `number`.

If you passed an array of status codes it would attempt to set them as the headers, which doesn't work.

With this PR, you can now pass either an array or a set of the statusCodes that will be accepted.

I have included tests in the like of the status 201 test, so that should cover it.