### PR TITLE
Create .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,9 @@
+.git/
+.github/
+node_modules/
+
+# CI test files
+test/
+
+# npm package files
+package-lock.json


### PR DESCRIPTION
Added .npmignore to remove unnecessary files when publishing to npm.

This halves the package size.