### PR TITLE
feat(bent): add http request timeout option for nodejs

### DIFF
--- a/src/nodejs.js
+++ b/src/nodejs.js
@@ -93,7 +93,7 @@ const decodings = res => {
   }
 }
 
-const mkrequest = (statusCodes, method, encoding, headers, baseurl) => (_url, body = null, _headers = {}) => {
+const mkrequest = (statusCodes, method, encoding, headers, baseurl) => { const inner = (_url, body = null, _headers = {}) => {
   _url = baseurl + (_url || '')
   const parsed = new URL(_url)
   let h
@@ -124,6 +124,9 @@ const mkrequest = (statusCodes, method, encoding, headers, baseurl) => (_url, bo
     c.set('accept-encoding', acceptEncoding)
   }
   return new Promise((resolve, reject) => {
+    if (inner.timeout && typeof inner.timeout === 'number' && inner.timeout > 0) {
+      Object.assign(request, { timeout: inner.timeout });
+    }
     const req = h.request(request, async res => {
       res = getResponse(res)
       res.on('error', reject)
@@ -173,6 +176,8 @@ const mkrequest = (statusCodes, method, encoding, headers, baseurl) => (_url, bo
       req.end()
     }
   })
+}
+return inner;
 }
 
 module.exports = bent(mkrequest)

--- a/test/test-basics.js
+++ b/test/test-basics.js
@@ -247,6 +247,7 @@ if (process.browser) {
       })
     })
     const request = bent('POST')
+    request.timeout = 1000 * 20
     const response = request('http://localhost:9999', { ok: true }, { 'content-type': 'application/jose+json' })
     const info = await response
     same(info.statusCode, 200)


### PR DESCRIPTION
fix: #59 #104 

I want to add a `timeout` option for nodejs http request.

The usage will be

```javascript
const req = bent('GET', 200, 201);
req.timeout = 1000 * 10;
(async () => {
    await req('http://192.123.21.12/hello', null, null);
})();
```

@mikeal  Please ignore the whitespace changes for this PR 

![image](https://user-images.githubusercontent.com/3260884/101332419-38023380-38b0-11eb-9447-ccd6b5e971f2.png)


Under the strict mode, we cannot use the assigned currying arrow function chain

```javascript
'use strict'
const b = () => req = () => {
  return new Promise((resolve, reject) => {
    console.log(req.data)
    resolve(1)
  })
}
```

Then, have to change to the following explicitly way, tha't why so many whitespace changes

```javascript
'use strict'
const b = () => {
  const req = () => {
    return new Promise((resolve, reject) => {
      console.log(req.data)
      resolve(1)
    })
  }
  return req
}
```



Thanks,
McGrady