### PR TITLE
Update core.js to throw more explicit error message

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -38,7 +38,7 @@ module.exports = mkrequest => (...args) => {
         headers = arg
       }
     } else {
-      throw new Error(`Unknown type: ${typeof arg}`)
+      throw new Error(`Unknown type: ${typeof arg}. Make sure to call bent() with the right argument types, current arguments: ${args.map(arg => '' + arg)}`)
     }
   })
 


### PR DESCRIPTION
If you call

```
bent(process.env.SOMETHING, "POST");
```
and the env variable `SOMETHING` is not set (it is `undefined`), bent will throw an exception and the traceback along with the message are not very helpful to debug the problem (I had to check the source code to find the solution).

Therefore I simply added a more explicit and helpful error message.