### PR TITLE
Remove undefined request headers

### DIFF
--- a/src/nodejs.js
+++ b/src/nodejs.js
@@ -108,7 +108,7 @@ const mkrequest = (statusCodes, method, encoding, headers, baseurl) => (_url, bo
     path: parsed.pathname + parsed.search,
     port: parsed.port,
     method: method,
-    headers: { ...(headers || {}), ..._headers },
+    headers: JSON.parse(JSON.stringify({ ...(headers || {}), ..._headers })),
     hostname: parsed.hostname
   }
   if (parsed.username || parsed.password) {

--- a/test/test-basics.js
+++ b/test/test-basics.js
@@ -252,4 +252,21 @@ if (process.browser) {
     same(info.statusCode, 200)
     server.close()
   })
+
+  test('undefined headers', async () => {  
+    const server = http.createServer((request, response) => {
+      response.statusCode = 200
+      response.end()
+    })
+    await new Promise((resolve, reject) => {
+      server.listen(9999, () => {
+        resolve()
+      })
+    })
+    const request = bent('POST')
+    const response = request('http://localhost:9999', { ok: true }, { Authorization: undefined })
+    const info = await response
+    same(info.statusCode, 200)
+    server.close()
+  })
 }


### PR DESCRIPTION
`http`/`https` throws an error when it receives any header with undefined value bringing the application to stop.

With this commit, `bent` will still be able to accept headers with undefined values but will remove them prior to sending the request.