### PR TITLE
Fix multipart/form-data being handled as json

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -46,6 +46,7 @@ const mkrequest = (statusCodes, method, encoding, headers, baseurl) => async (_u
 
   if (body) {
     if (body instanceof ArrayBuffer ||
+      body instanceof FormData ||
       ArrayBuffer.isView(body) ||
       typeof body === 'string'
     ) {


### PR DESCRIPTION
When working with web workers in the browser (or CloudFlare Workers) we do not have access to ``FormData.getHeaders()`` to construct requests (example in https://github.com/mikeal/bent/issues/121#issuecomment-708462122) and bent will default to application/json whereas fetch should handle the content type and boundary headers when passing an instance of FormData to it.

This pull request changes bent to skip adding the application/json content-type header and stringifying the body when the body is an instanceof FormData.

